### PR TITLE
Add beginTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Elide is tested on:
     - [create](#create)
     - [update](#update)
     - [delete](#delete)
-    - [commit](#commit)
+    - [beginTransaction](#beginTransaction)
+    - [commitTransaction](#commitTransaction)
+    - [rollbackTransaction](#rollbackTransaction)
 
 ### Schema
 The schema is a javascript object composed of two sections: `stores` and `models`.
@@ -175,13 +177,32 @@ elide.delete('company', {id: 1})
   });
 ```
 
-#### commit() → Promise()
+#### beginTransaction() → Promise()
+Lets stores know that a transaction is beginning.
+```javascript
+elide.beginTransaction()
+  .then(function() {
+    // do lots of awesome stuff in a batch
+    // or mark the UI as ready for updates
+  })
+```
+
+#### commitTransaction() → Promise()
 Commit receives no value but returns a Promise so errors can be caught
 ```javascript
-elide.commit()
+elide.commitTransaction()
   .then(() => {
     // there is no value received
   }).catch((error) => {
     // inspect error to see what went wrong
   });
+```
+
+#### rollbackTransaction() → Promise()
+Lets stores know that the current transaction was cancelled
+```javascript
+elide.rollbackTransaction()
+  .then(function() {
+    // reset the UI (or preform the cancel button action)
+  })
 ```

--- a/lib/datastores/datastore.js
+++ b/lib/datastores/datastore.js
@@ -77,7 +77,7 @@ class Datastore {
       throw new Error(ERROR_MUST_FIND_QUERY);
     }
 
-    return this._promise.reject('Not implemented');
+    return this._promise.reject(new Error('Not implemented'));
   }
 
   /**
@@ -90,7 +90,7 @@ class Datastore {
    * @return  {Promise}       - a promise that will eventually receieve the results
    */
   create(model, state) {
-    return this._promise.reject('Not implemented');
+    return this._promise.reject(new Error('Not implemented'));
   }
 
   /**
@@ -102,7 +102,7 @@ class Datastore {
    * @return  {Promise}           - a promise that will eventually receieve the results
    */
   update(model, state) {
-    return this._promise.reject('Not implemented');
+    return this._promise.reject(new Error('Not implemented'));
   }
 
   /**
@@ -114,7 +114,21 @@ class Datastore {
    * @return  {Promise}           - a promise that will eventually receieve the results
    */
   delete(model, state) {
-    return this._promise.reject('Not implemented');
+    return this._promise.reject(new Error('Not implemented'));
+  }
+
+  /**
+   * Signals to stores that a set of atomic events is beginning
+   */
+  beginTransaction() {
+    return this._promise.reject(new Error('Not implemented'));
+  }
+
+  /**
+   * Signals that the current set of atomic events should be discarded
+   */
+  rollbackTransaction() {
+    return this._promise.reject(new Error('Not implemented'));
   }
 
   /**
@@ -123,13 +137,13 @@ class Datastore {
    * @param   {Array}   patches - the list of patches to apply to the store
    * @return  {Promise}         - a promise that receives the results of the operation
    */
-  commit(patches) {
-    return this._promise.reject('Not implemented');
+  commitTransaction(patches) {
+    return this._promise.reject(new Error('Not implemented'));
   }
 
   /**
    * Specify a datastore that is upstream of this one. This is where data goes
-   * when we call {@link Datastore#commit}
+   * when we call {@link Datastore#commitTransaction}
    *
    * @param   {Datastore} store - the store that is upstream of this store
    */

--- a/lib/datastores/jsonapidatastore.js
+++ b/lib/datastores/jsonapidatastore.js
@@ -1142,7 +1142,7 @@ class JsonApiDatastore extends Datastore {
    *                           	data: Object
    *                           }
    */
-  commit(patches) {
+  commitTransaction(patches) {
     let unrootedDiffs = this._parseObjects(patches);
 
     let diffTree = {};

--- a/lib/datastores/memorydatastore.js
+++ b/lib/datastores/memorydatastore.js
@@ -861,11 +861,19 @@ class MemoryDatastore extends Datastore {
   }
 
   beginTransaction() {
+    if (this._inTransaction) {
+      return this._promise.reject(new Error('Simultanious transactions not supported'));
+    }
+
     this._inTransaction = true;
     return this._promise.resolve();
   }
 
   rollbackTransaction() {
+    if (!this._inTransaction) {
+      return this._promise.reject(new Error('Cannot rollback without an open transaction'));
+    }
+
     this._data = clone(this._snapshot);
     this._inTransaction = false;
     return this._promise.resolve();

--- a/lib/datastores/memorydatastore.js
+++ b/lib/datastores/memorydatastore.js
@@ -32,6 +32,7 @@ class MemoryDatastore extends Datastore {
   constructor(Promise, ttl, baseURL, models) {
     super(Promise, ttl, baseURL, models);
 
+    this._inTransaction = false;
     this._data = {};
     this._meta = {};
     this._ttlCache = {};
@@ -730,20 +731,19 @@ class MemoryDatastore extends Datastore {
 
     let toReturn;
     let toCreate = {};
+    let relationPatches = [];
 
     if (!state) {
-      let err = new Error(ERROR_NO_STATE_GIVEN.replace('${method}', 'create'));
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_NO_STATE_GIVEN.replace('${method}', 'create');
 
     } else if (state.id) {
-      let err = new Error(ERROR_CANNOT_CREATE_WITH_ID);
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_CANNOT_CREATE_WITH_ID;
 
     } else {
       let id = uuid.v4();
       toCreate.id = id;
-
-      let relationPatches = [];
 
       this._updateSimpleProps(model, toCreate, state);
 
@@ -757,15 +757,21 @@ class MemoryDatastore extends Datastore {
         willReject,
         withReason
       ] = this._updateLinkProperties(model, toReturn, state, true, 'create');
-
-      if (!willReject) {
-        this._setData(model, toCreate);
-        jsonpatch.apply(this._data, relationPatches);
-      } else {
-        return this._promise.reject(new Error(withReason));
-      }
     }
 
+    if (willReject) {
+      return this._promise.reject(new Error(withReason));
+    }
+
+    if (!this._inTransaction && this._upstream) {
+      return this._upstream.create(model, toReturn)
+        .then((createdInstance) => {
+          this._setData(model, createdInstance);
+        });
+    }
+
+    this._setData(model, toCreate);
+    jsonpatch.apply(this._data, relationPatches);
     return this._promise.resolve(toReturn);
   }
 
@@ -775,25 +781,23 @@ class MemoryDatastore extends Datastore {
     let withReason;
 
     let toUpdate;
+    let relationPatches = [];
 
     if (!state) {
-      let err = new Error(ERROR_NO_STATE_GIVEN
-                    .replace('${method}', 'update'));
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_NO_STATE_GIVEN.replace('${method}', 'update');
 
     } else if (!state.id) {
-      let err = new Error(ERROR_CANNOT_UPDATE_WITHOUT_ID);
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_CANNOT_UPDATE_WITHOUT_ID;
 
     } else if (!this._getData(model, state.id)) {
-      let err = new Error(ERROR_CANNOT_UPDATE_MISSING_RECORD
+      willReject = true;
+      withReason = ERROR_CANNOT_UPDATE_MISSING_RECORD
                     .replace('${model}', model)
-                    .replace('${method}', 'update'));
-      return this._promise.reject(err);
+                    .replace('${method}', 'update');
 
     } else {
-      let relationPatches = [];
-
       toUpdate = this._getData(model, state.id);
 
       this._updateSimpleProps(model, toUpdate, state);
@@ -802,14 +806,21 @@ class MemoryDatastore extends Datastore {
         willReject,
         withReason
       ] = this._updateLinkProperties(model, toUpdate, state, false, 'update');
-
-      if (!willReject) {
-        jsonpatch.apply(this._data, relationPatches);
-        this._setData(model, toUpdate);
-      } else {
-        return this._promise.reject(new Error(withReason));
-      }
     }
+
+    if (willReject) {
+      return this._promise.reject(new Error(withReason));
+    }
+
+    if (!this._inTransaction && this._upstream) {
+      return this._upstream.update(model, toUpdate)
+        .then((updatedInstance) => {
+          this._setData(model, updatedInstance);
+        });
+    }
+
+    jsonpatch.apply(this._data, relationPatches);
+    this._setData(model, toUpdate);
 
     return this._promise.resolve(toUpdate);
   }
@@ -820,23 +831,43 @@ class MemoryDatastore extends Datastore {
     let withReason;
 
     if (!state) {
-      let err = new Error(ERROR_NO_STATE_GIVEN.replace('${method}', 'delete'));
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_NO_STATE_GIVEN.replace('${method}', 'delete');
 
     } else if (!state.id) {
-      let err = new Error(ERROR_CANNOT_UPDATE_WITHOUT_ID);
-      return this._promise.reject(err);
+      willReject = true;
+      withReason = ERROR_CANNOT_UPDATE_WITHOUT_ID;
 
     } else if (!this._getData(model, state.id)) {
-      let err = new Error(ERROR_CANNOT_UPDATE_MISSING_RECORD
+      willReject = true;
+      withReason = ERROR_CANNOT_UPDATE_MISSING_RECORD
                     .replace('${model}', model)
-                    .replace('${method}', 'delete'));
-      return this._promise.reject(err);
+                    .replace('${method}', 'delete');
 
-    } else {
-      this._deleteData(model, state.id);
     }
 
+    if (willReject) {
+      return this._promise.reject(new Error(withReason));
+    }
+
+    if (!this._inTransaction && this._upstream) {
+      return this._upstream.delete(model, state)
+        .then(() => {
+          this._deleteData(model, state.id);
+        });
+    }
+
+    return this._promise.resolve(this._deleteData(model, state.id));
+  }
+
+  beginTransaction() {
+    this._inTransaction = true;
+    return this._promise.resolve();
+  }
+
+  rollbackTransaction() {
+    this._data = clone(this._snapshot);
+    this._inTransaction = false;
     return this._promise.resolve();
   }
 
@@ -849,7 +880,7 @@ class MemoryDatastore extends Datastore {
    *                       local copys of objects be refetched after the commit if the promise
    *                       rejects or if the promise succeedes and is called with `true`
    */
-  commit(_) {
+  commitTransaction(_) {
     let willReject = false;
 
     if (!this._upstream) {
@@ -858,7 +889,7 @@ class MemoryDatastore extends Datastore {
 
     let patches = jsonpatch.compare(this._snapshot, this._data);
 
-    return this._upstream.commit(patches).then((upstreamResults) => {
+    return this._upstream.commitTransaction(patches).then((upstreamResults) => {
       if (upstreamResults) {
         for (let i = 0; i < upstreamResults.length; i++) {
           let result = upstreamResults[i];

--- a/lib/elide.js
+++ b/lib/elide.js
@@ -245,7 +245,6 @@ class Elide {
     return new Query(store, model, id, opts);
   }
 
-
   create(model, state) {
     let store = this._getStoreForModel(model);
     return store.create(model, state);
@@ -261,9 +260,21 @@ class Elide {
     return store.delete(model, state);
   }
 
-  commit() {
+  beginTransaction() {
+    return this._promise.all(this._stores.map((store) => {
+      return store.beginTransaction();
+    }));
+  }
+
+  rollbackTransaction() {
+    return this._promise.all(this._stores.map((store) => {
+      return store.rollbackTransaction();
+    }));
+  }
+
+  commitTransaction() {
     return this._promise.all(this._storesThatCommit.map((storeName) => {
-      return this._stores[storeName].commit();
+      return this._stores[storeName].commitTransaction();
     }));
   }
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "elide-js",
   "description": "Talk to a JSON API compliant server",
   "license": "Apache-2.0",
-  "authors": "Clay Reimann <clayreimann@yahoo-inc.com>",
-  "contributors": [],
+  "authors": "Clay Reimann <clayreimann@gmail.com>",
+  "contributors": [
+    "Arun Thomas <arunthomas207@gmail.com>",
+    "Shad Sharma <shadanan@gmail.com>"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/yahoo/elide-js.git"

--- a/spec/elide.spec.js
+++ b/spec/elide.spec.js
@@ -113,8 +113,8 @@ describe('Elide', function() {
       }).then(done).catch(done);
     });
 
-    it('should have #commit', function() {
-      expect(elide.commit).to.be.a('function');
+    it('should have #commitTransaction', function() {
+      expect(elide.commitTransaction).to.be.a('function');
     });
   });
 

--- a/spec/stores/datastore.spec.js
+++ b/spec/stores/datastore.spec.js
@@ -143,16 +143,16 @@ describe('Datastore', function() {
     });
   });
 
-  describe('#commit', function() {
+  describe('#commitTransaction', function() {
     it('should return a promise', function() {
       var foo = new FooStore(ES6Promise, undefined, undefined, {});
-      var promise = foo.commit();
+      var promise = foo.commitTransaction();
       expect(promise).to.be.an.instanceof(ES6Promise);
     });
 
     it('should throw an error if no _commit function exists', function() {
       var ds = new Datastore(ES6Promise, undefined, undefined, {});
-      expect(ds.commit()).to.eventually.be.rejectedWith('Not implemented');
+      expect(ds.commitTransaction()).to.eventually.be.rejectedWith('Not implemented');
     });
   });
 

--- a/spec/stores/jsonapidatastore.spec.js
+++ b/spec/stores/jsonapidatastore.spec.js
@@ -410,7 +410,7 @@ describe('JsonApiDatastore', function() {
 
   });
 
-  describe('#commit', function() {
+  describe('#commitTransaction', function() {
     var store;
     var objects;
     var models;
@@ -491,7 +491,7 @@ describe('JsonApiDatastore', function() {
 
       var q = new Query(store, 'person', 1);
       store.find(q).then(function(person) {
-        return store.commit(patch.compare(models, objects));
+        return store.commitTransaction(patch.compare(models, objects));
       }).then(done).catch(done);
     });
 
@@ -505,7 +505,7 @@ describe('JsonApiDatastore', function() {
         pets: []
       };
 
-      store.commit(patch.compare(models, objects)).then(function(objects) {
+      store.commitTransaction(patch.compare(models, objects)).then(function(objects) {
         expect(objects).to.deep.equal([
           {
             type: 'person',


### PR DESCRIPTION
**Breaking changes**

Allow callers to differentiate between serial and batch modes. This is new behavior, to retain the previous behavior callers will have to add `beginTransaction` before any writes take place and again after they `commitTransaction`.
