### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/yahoo/elide-js.png?label=ready&title=Ready)](https://waffle.io/yahoo/elide-js)
 [![Build Status](https://travis-ci.org/yahoo/elide-js.svg?branch=master)](https://travis-ci.org/yahoo/elide-js) [![npm version](https://badge.fury.io/js/elide-js.svg)](https://badge.fury.io/js/elide-js) [![Code Climate](https://codeclimate.com/github/yahoo/elide-js/badges/gpa.svg)](https://codeclimate.com/github/yahoo/elide-js)
 
 Elide


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/yahoo/elide-js

This was requested by a real person (user clayreimann) on waffle.io, we're not trying to spam you.
